### PR TITLE
Established compatibility with the latest (6.2.0.8) dev-build of QuickShop-Hikari

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ltd.rymc</groupId>
     <artifactId>QuickShopForm</artifactId>
-    <version>2.1.4</version>
+    <version>2.1.5</version>
     <packaging>jar</packaging>
 
     <name>QuickShopForm</name>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -85,19 +85,27 @@
         <dependency>
             <groupId>com.ghostchu</groupId>
             <artifactId>quickshop-bukkit</artifactId>
-            <version>5.2.0.9</version>
+            <version>6.2.0.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ghostchu</groupId>
             <artifactId>quickshop-api</artifactId>
-            <version>5.2.0.9</version>
+            <version>6.2.0.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ghostchu</groupId>
             <artifactId>quickshop-common</artifactId>
-            <version>5.2.0.9</version>
+            <version>6.2.0.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Made use of in the internal QuickShop-API, and somehow, this dependency doesn't trickle down... -->
+        <!-- Didn't seem to be an issue back at 5.2.0.9; could maybe use more research. -->
+        <dependency>
+            <groupId>com.ghostchu</groupId>
+            <artifactId>simplereloadlib</artifactId>
+            <version>1.1.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/ltd/rymc/form/quickshop/handler/ShopHandlerHikari.java
+++ b/src/main/java/ltd/rymc/form/quickshop/handler/ShopHandlerHikari.java
@@ -1,7 +1,7 @@
 package ltd.rymc.form.quickshop.handler;
 
 import com.ghostchu.quickshop.api.QuickShopAPI;
-import com.ghostchu.quickshop.api.event.ShopInfoPanelEvent;
+import com.ghostchu.quickshop.api.event.general.ShopInfoPanelEvent;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.ShopManager;
 import ltd.rymc.form.quickshop.QuickShopForm;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: QuickShopForm
 version: '${project.version}'
 main: ltd.rymc.form.quickshop.QuickShopForm
-api-version: 1.13
+api-version: 1.18
 depend: [ floodgate ]
 softdepend: [ QuickShop, QuickShop-Hikari ]
 authors: [ RENaa_FD ]


### PR DESCRIPTION
Since there was a great refactoring when it comes to FQNs of events, a single occurrence had to be patched, in order to get the plugin back up and running.